### PR TITLE
Point Giscus comments to the correct repo

### DIFF
--- a/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
+        env:
+          HUGO_VERSION: "0.124.1"
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_05C910A03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)

--- a/hugo.toml
+++ b/hugo.toml
@@ -13,12 +13,16 @@ theme = 'maverick'
   author = 'Jack Nicol'
 
   [params.comments]
-    githubRepo = 'canhtran/maverick'
+    githubRepo = 'Jicol95/jack-nicol'
     theme = 'github-light'
 
 
 [menu]
   [[menu.main]]
+    identifier = "posts"
+    name = "Post"
+    url = "/posts/"
+    weight = -200
 
 [markup]
   [markup.goldmark.renderer]


### PR DESCRIPTION
## Summary
- Updates `githubRepo` in `hugo.toml` from `canhtran/maverick` (the theme author's repo) to `Jicol95/jack-nicol`

## Before merging
- Enable Discussions on this repo (Settings → Features → Discussions)
- Install the [Giscus GitHub App](https://github.com/apps/giscus) and grant it access to this repo