### PR TITLE
Fix typos in homepage content

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,8 +4,8 @@ I’m a software engineer with a passion for distributed systems.
 
 Currently, you’ll find me as a Senior Engineer at Europe’s leading spend management solution, [Pleo](https://pleo.io) 💳. I work with Kotlin, Postgres, Kafka, Kubernetes, and more. My goal is to ensure businesses handle out-of-pocket spending and employee reimbursements with ease.
 
-Previously, I was at [STC Insiso](https://www.stcinsiso.com/), assisting startups in realizing their tech products, ranging from [risk anlysis software](https://salus-technical.com/software/bowtie-master/) 📊 to developing point-of-sale software for a [beer kiosk](https://www.ebar.co.uk/) start-up 🍺. There I worked with C# and TypeScript.
+Previously, I was at [STC Insiso](https://www.stcinsiso.com/), assisting startups in realizing their tech products, ranging from [risk analysis software](https://salus-technical.com/software/bowtie-master/) 📊 to developing point-of-sale software for a [beer kiosk](https://www.ebar.co.uk/) start-up 🍺. There I worked with C# and TypeScript.
 
-I'm interested in hearing about backend engineer roles with the opertunity to work on distributed systems at scale. If you think I'd be a good fit, checkout my [resume](https://drive.google.com/file/d/1-oVJvIvBT51p_ReARcxxl5qoYq5uUbX9/view).
+I'm interested in hearing about backend engineer roles with the opportunity to work on distributed systems at scale. If you think I'd be a good fit, checkout my [resume](https://drive.google.com/file/d/1-oVJvIvBT51p_ReARcxxl5qoYq5uUbX9/view).
 
 You can find me on [LinkedIn](https://www.linkedin.com/in/jicol95/) and [GitHub](https://github.com/jicol95).


### PR DESCRIPTION
Fix two typos on the homepage:
- "anlysis" → "analysis"
- "opertunity" → "opportunity"