### PR TITLE
Build Hugo in CI instead of relying on Azure Oryx

### DIFF
--- a/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
@@ -35,7 +35,7 @@ jobs:
           action: "upload"
           app_location: "/"
           api_location: ""
-          output_location: "public"
+          output_location: ""
           app_build_command: "hugo"
           skip_app_build: false
 

--- a/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
@@ -14,30 +14,23 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
-    env:
-      HUGO_VERSION: "0.145.0"
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
           lfs: false
-      - name: Install Hugo
-        run: |
-          wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz
-          tar -xzf hugo.tar.gz
-          sudo mv hugo /usr/local/bin/hugo
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
+        env:
+          HUGO_VERSION: "0.145.0"
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_05C910A03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
           app_location: "/"
           api_location: ""
-          output_location: ""
-          app_build_command: "hugo"
-          skip_app_build: false
+          output_location: "public"
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
@@ -35,9 +35,9 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_05C910A03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "/"
+          app_location: "public"
           api_location: ""
-          output_location: "public"
+          output_location: ""
           skip_app_build: true
 
   close_pull_request_job:

--- a/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
           lfs: false
       - name: Build And Deploy
         id: builddeploy

--- a/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
@@ -14,26 +14,31 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    env:
+      HUGO_VERSION: "0.145.0"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           lfs: false
+      - name: Install Hugo
+        run: |
+          wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz
+          tar -xzf hugo.tar.gz
+          sudo mv hugo /usr/local/bin/hugo
+      - name: Build
+        run: hugo
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
-        env:
-          HUGO_VERSION: "0.124.1"
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_05C910A03 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "public" # Built app content directory - optional
-          ###### End of Repository/Build Configurations ######
+          app_location: "/"
+          api_location: ""
+          output_location: "public"
+          skip_app_build: true
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
@@ -26,8 +26,6 @@ jobs:
           wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz
           tar -xzf hugo.tar.gz
           sudo mv hugo /usr/local/bin/hugo
-      - name: Build
-        run: hugo
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -35,10 +33,11 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_05C910A03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "public"
+          app_location: "/"
           api_location: ""
-          output_location: ""
-          skip_app_build: true
+          output_location: "public"
+          app_build_command: "hugo"
+          skip_app_build: false
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://jacknicol.com'
-languageCode = 'en-us'
+languageCode = 'en-gb'
 title = 'Jack Nicol'
 [pagination]
   pagerSize = 3

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,7 +1,8 @@
 baseURL = 'https://jacknicol.com'
 languageCode = 'en-us'
 title = 'Jack Nicol'
-paginate = 3
+[pagination]
+  pagerSize = 3
 theme = 'maverick'
 
 [permalinks]


### PR DESCRIPTION
## Summary
- Install Hugo directly in the workflow (currently pinned to `0.145.0`) rather than letting Azure's Oryx builder pick the version
- Run `hugo` as a build step, then pass `public/` to the deploy action with `skip_app_build: true`
- Bump `actions/checkout` from v3 to v4

To upgrade Hugo in future, just bump `HUGO_VERSION` at the top of the workflow.