### PR TITLE
Deploy via SWA CLI to bypass Oryx submodule issue

### DIFF
--- a/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
@@ -14,26 +14,26 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    env:
+      HUGO_VERSION: "0.145.0"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           lfs: false
-      - name: Build And Deploy
-        id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+      - name: Install Hugo
+        run: |
+          wget -O hugo.tar.gz https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz
+          tar -xzf hugo.tar.gz
+          sudo mv hugo /usr/local/bin/hugo
+      - name: Install SWA CLI
+        run: npm install -g @azure/static-web-apps-cli
+      - name: Build
+        run: hugo
+      - name: Deploy
         env:
-          HUGO_VERSION: "0.124.1"
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_05C910A03 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "public" # Built app content directory - optional
-          ###### End of Repository/Build Configurations ######
+          AZURE_STATIC_WEB_APPS_API_TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_05C910A03 }}
+        run: swa deploy ./public --env production
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
+++ b/.github/workflows/azure-static-web-apps-thankful-bush-05c910a03.yml
@@ -31,9 +31,7 @@ jobs:
       - name: Build
         run: hugo
       - name: Deploy
-        env:
-          AZURE_STATIC_WEB_APPS_API_TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_05C910A03 }}
-        run: swa deploy ./public --env production
+        run: swa deploy ./public --env production --deployment-token ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_THANKFUL_BUSH_05C910A03 }}
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://jacknicol.com'
-languageCode = 'en-us'
+languageCode = 'en-gb'
 title = 'Jack Nicol'
 [pagination]
   pagerSize = 3

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,7 +1,8 @@
 baseURL = 'https://jacknicol.com'
 languageCode = 'en-us'
 title = 'Jack Nicol'
-paginate = 3
+[pagination]
+  pagerSize = 3
 theme = 'maverick'
 
 [permalinks]


### PR DESCRIPTION
## Summary
- Replaces the Azure deploy action with the SWA CLI approach
- Installs Hugo directly at a pinned version, builds the site, then deploys `./public` via `swa deploy`
- Bypasses Oryx entirely, which was copying repo files to its own temp directory without submodule contents — causing Hugo to build with no theme

To upgrade Hugo in future, bump `HUGO_VERSION` in the workflow.