### PR TITLE
Switch Utterances comment theme to github-dark

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -14,7 +14,7 @@ theme = 'maverick'
 
   [params.comments]
     githubRepo = 'Jicol95/jack-nicol'
-    theme = 'github-light'
+    theme = 'github-dark'
 
 
 [menu]


### PR DESCRIPTION
Switches the Utterances comment widget theme from `github-light` to `github-dark`.